### PR TITLE
0847909, 0846585 Bug Resolved

### DIFF
--- a/aws-access-analyzer/info.json
+++ b/aws-access-analyzer/info.json
@@ -173,7 +173,6 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "value": "",
           "tooltip": "Specifies the next page token. Not required for the first page. And you can find 'nextToken' value in first page data.",
           "description": "(Optional) The next page token is used for paginating through large result sets. A next page token will be returned whenever the set of available results exceeds the current page size. You can use this parameter to retrieve the next page records using the 'nextToken' value and it is not required for the first page."
         }
@@ -387,7 +386,6 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "value": "",
           "tooltip": "Specifies the next page token. Not required for the first page. And you can find 'nextToken' value in first page data.",
           "description": "(Optional) The next page token is used for paginating through large result sets. A next page token will be returned whenever the set of available results exceeds the current page size. You can use this parameter to retrieve the next page records using the 'nextToken' value and it is not required for the first page."
         }
@@ -585,8 +583,6 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "value": {},
-          "placeholder": {},
           "tooltip": "Specifies the filter query.",
           "description": "(Optional) Specify a query using which you want to filter the finding list retrieved using AWS Access Analyzer. "
         },
@@ -597,8 +593,6 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "value": {},
-          "placeholder": {},
           "tooltip": "Specifies the sort attributes",
           "description": "(Optional) Specify the attributes using which you want to sort the finding list retrieved using AWS Access Analyzer. "
         },
@@ -609,7 +603,6 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "value": "",
           "tooltip": "Specifies the next page token. Not required for the first page. And you can find 'nextToken' value in first page data.",
           "description": "(Optional) The next page token is used for paginating through large result sets. A next page token will be returned whenever the set of available results exceeds the current page size. You can use this parameter to retrieve the next page records using the 'nextToken' value and it is not required for the first page.  "
         }
@@ -723,7 +716,6 @@
           "required": true,
           "editable": true,
           "visible": true,
-          "value": "",
           "tooltip": "Specifies the id of findings",
           "description": "Specify the ID of findings whose details you want to retrieve using AWS Access Analyzer. "
         }
@@ -906,26 +898,43 @@
           "description": "Specify the ARN of the analyzer whose findings' status you want to update using AWS Access Analyzer."
         },
         {
-          "title": "Resource ARN",
-          "type": "text",
-          "name": "resource_arn",
+          "title": "Update By",
+          "type": "select",
+          "name": "update_by",
           "required": true,
           "editable": true,
           "visible": true,
-          "tooltip": "Specify the arn of resources.",
-          "description": "Specify the ARN of resources whose findings' status you want to update using the specified analyzer."
-        },
-        {
-          "title": "ID List",
-          "type": "json",
-          "name": "ids",
-          "required": true,
-          "editable": true,
-          "visible": true,
-          "value": [],
-          "placeholder": ["id1", "id2"],
-          "tooltip": "Comma separated list of ID's.",
-          "description": "Specify a comma-separated list of findings' IDs whose status you want to update using AWS Access Analyzer. "
+          "description": "Select options from which you want to update the findings.",
+          "value": "Resource ARN",
+          "options": ["Resource ARN", "Findings IDs"],
+          "onchange": {
+            "Resource ARN": [
+              {
+                "title": "Resource ARN",
+                "type": "text",
+                "name": "resource_arn",
+                "required": true,
+                "editable": true,
+                "visible": true,
+                "tooltip": "Specify the arn of resources.",
+                "description": "Specify the ARN of resources whose findings' status you want to update using the specified analyzer."
+              }
+            ],
+            "Findings IDs": [
+              {
+                "title": "ID List",
+                "type": "json",
+                "name": "ids",
+                "required": true,
+                "editable": true,
+                "visible": true,
+                "value": [],
+                "placeholder": ["id1", "id2"],
+                "tooltip": "Comma separated list of ID's.",
+                "description": "Specify a comma-separated list of findings' IDs whose status you want to update using AWS Access Analyzer. "
+              }
+            ]
+          }
         },
         {
           "title": "Status",
@@ -949,7 +958,6 @@
           "required": false,
           "editable": true,
           "visible": true,
-          "value": "",
           "tooltip": "Specifies the client token",
           "description": "Specify the client token to update the status of the specified findings. "
         }

--- a/aws-access-analyzer/operations.py
+++ b/aws-access-analyzer/operations.py
@@ -159,6 +159,11 @@ def list_findings(config, params):
     size = params.get("size", 10)
     filter_q = params.get("filter", {})
     sort = params.get("sort", {})
+    if filter_q in ["{}", "[]", ""]:
+        filter_q = {}
+
+    if sort in ["{}", "[]", ""]:
+        sort = {}
 
     next_token = params.get("next_token")  # optional and not required in first time
     if next_token and len(next_token) > 0 and sort:
@@ -218,16 +223,24 @@ def update_findings(config, params):
     client = _get_aws_client(config, params, 'accessanalyzer')
     analyzer_arn = params.get("analyzer_arn")
     resource_arn = params.get("resource_arn")
-    client_token = params.get("client_token")
     ids = params.get("ids", [])  # json list
     status = params.get("status", "ACTIVE")  # 'ACTIVE' | 'ARCHIVED'
-    response = client.update_findings(
-        analyzerArn=analyzer_arn,
-        clientToken=client_token,
-        ids=ids,
-        resourceArn=resource_arn,
-        status=status
-    )
+    client_token = params.get("client_token")
+    config_type = params.pop("config_type")
+    if config_type == "Resource ARN":
+        response = client.update_findings(
+            analyzerArn=analyzer_arn,
+            clientToken=client_token,
+            resourceArn=resource_arn,
+            status=status
+        )
+    else:
+        response = client.update_findings(
+            analyzerArn=analyzer_arn,
+            clientToken=client_token,
+            ids=ids,
+            status=status
+        )
     return response
 
 

--- a/aws-access-analyzer/operations.py
+++ b/aws-access-analyzer/operations.py
@@ -226,8 +226,8 @@ def update_findings(config, params):
     ids = params.get("ids", [])  # json list
     status = params.get("status", "ACTIVE")  # 'ACTIVE' | 'ARCHIVED'
     client_token = params.get("client_token")
-    config_type = params.pop("config_type")
-    if config_type == "Resource ARN":
+    update_by = params.pop("update_by")
+    if update_by == "Resource ARN":
         response = client.update_findings(
             analyzerArn=analyzer_arn,
             clientToken=client_token,

--- a/aws-access-analyzer/playbooks/playbooks.json
+++ b/aws-access-analyzer/playbooks/playbooks.json
@@ -2,7 +2,7 @@
   "type": "workflow_collections",
   "data": [
     {
-      "uuid": "d3c514d1-b86b-45db-ac48-0b60cb26a57e",
+      "uuid": "147cc835-a091-42e7-be78-8260a167885e",
       "@type": "WorkflowCollection",
       "name": "Sample - AWS Access Analyzer - 1.1.0",
       "description": "AWS Access Analyzer helps you identify the resources in your organization and accounts, such as Amazon S3 buckets or IAM roles, shared with an external entity, enabling you to identify unintended access to your resources and data, which is a security risk. ",
@@ -14,8 +14,8 @@
       "workflows": [
         {
           "@type": "Workflow",
-          "uuid": "3dc31548-3b95-4203-bcdc-06d1341b4784",
-          "collection": "/api/3/workflow_collections/d3c514d1-b86b-45db-ac48-0b60cb26a57e",
+          "uuid": "76345f2a-b8ff-48ff-aba4-ed0b248017cd",
+          "collection": "/api/3/workflow_collections/147cc835-a091-42e7-be78-8260a167885e",
           "triggerLimit": null,
           "description": "Retrieves a list of analyzers based on the analyzer type and other input parameters you have specified. ",
           "name": "List Analyzers",
@@ -28,16 +28,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/cded81a5-f755-4532-b5b0-d4273c9a516e",
+          "triggerStep": "/api/3/workflow_steps/390be2a4-cbe0-48c1-92d3-e74d8f880c0d",
           "steps": [
             {
-              "uuid": "cded81a5-f755-4532-b5b0-d4273c9a516e",
+              "uuid": "390be2a4-cbe0-48c1-92d3-e74d8f880c0d",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "acbf2d3d-dcfb-4e43-82d8-f2cb3c7d6777",
+                "route": "2a7c170f-1d0f-4489-b25b-1bdbd3b0f334",
                 "title": "AWS Access Analyzer: List Analyzers",
                 "resources": [
                   "alerts"
@@ -57,7 +57,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "d87de94b-e904-41e9-843e-52be70df5568",
+              "uuid": "468adb9a-467b-4c66-af80-ad98a809ad72",
               "@type": "WorkflowStep",
               "name": "List Analyzers",
               "description": null,
@@ -67,8 +67,7 @@
                 "config": "''",
                 "params": {
                   "assume_role": false,
-                  "size": 10,
-                  "next_token": ""
+                  "size": 10
                 },
                 "version": "1.1.0",
                 "connector": "aws-access-analyzer",
@@ -86,19 +85,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "ca72b2bc-3448-4f11-8e24-46bd87fda7c4",
+              "uuid": "98eb7897-873f-4cfe-b9fa-11009101c69c",
               "label": null,
               "isExecuted": false,
               "name": "Start-> List Analyzers",
-              "sourceStep": "/api/3/workflow_steps/cded81a5-f755-4532-b5b0-d4273c9a516e",
-              "targetStep": "/api/3/workflow_steps/d87de94b-e904-41e9-843e-52be70df5568"
+              "sourceStep": "/api/3/workflow_steps/390be2a4-cbe0-48c1-92d3-e74d8f880c0d",
+              "targetStep": "/api/3/workflow_steps/468adb9a-467b-4c66-af80-ad98a809ad72"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "e5d0ca20-d859-4577-9d9f-896c65e511de",
-          "collection": "/api/3/workflow_collections/d3c514d1-b86b-45db-ac48-0b60cb26a57e",
+          "uuid": "7fbce344-210c-4624-8eec-5829c1c94b05",
+          "collection": "/api/3/workflow_collections/147cc835-a091-42e7-be78-8260a167885e",
           "triggerLimit": null,
           "description": "Retrieves information about the specified analyzer based on the analyzer name and other input parameters you have specified.",
           "name": "Get analyzer details",
@@ -111,16 +110,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/1cc0e539-4214-426c-9cde-217fc264fcf8",
+          "triggerStep": "/api/3/workflow_steps/ee152a06-4832-48de-a5c8-10ca1b9674f1",
           "steps": [
             {
-              "uuid": "1cc0e539-4214-426c-9cde-217fc264fcf8",
+              "uuid": "ee152a06-4832-48de-a5c8-10ca1b9674f1",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "21f22c8d-b89b-4557-86dc-19eb20a2b0f8",
+                "route": "47049d45-7c41-4793-9afa-aee4e09fea4d",
                 "title": "AWS Access Analyzer: Get analyzer details",
                 "resources": [
                   "alerts"
@@ -140,7 +139,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "46f7ed3c-92d1-4b90-906a-62e22a8ae587",
+              "uuid": "bdfc53d6-ba9d-4b51-b799-2ff9678927b4",
               "@type": "WorkflowStep",
               "name": "Get analyzer details",
               "description": null,
@@ -167,19 +166,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "47d65928-2014-4cab-8746-d547ad5abdf5",
+              "uuid": "e383f848-8074-4841-9f8d-28634a827ea5",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Get analyzer details",
-              "sourceStep": "/api/3/workflow_steps/1cc0e539-4214-426c-9cde-217fc264fcf8",
-              "targetStep": "/api/3/workflow_steps/46f7ed3c-92d1-4b90-906a-62e22a8ae587"
+              "sourceStep": "/api/3/workflow_steps/ee152a06-4832-48de-a5c8-10ca1b9674f1",
+              "targetStep": "/api/3/workflow_steps/bdfc53d6-ba9d-4b51-b799-2ff9678927b4"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "f2730195-cf0e-43a4-b36b-cc6efe2b33f9",
-          "collection": "/api/3/workflow_collections/d3c514d1-b86b-45db-ac48-0b60cb26a57e",
+          "uuid": "eb6c9b2c-ce53-4e71-b528-03520623c752",
+          "collection": "/api/3/workflow_collections/147cc835-a091-42e7-be78-8260a167885e",
           "triggerLimit": null,
           "description": "Retrieves a list of specified resource types that have been analyzed by the specified analyzer based on the analyzer ARN, resource type, and other input parameters you have specified. ",
           "name": "List of Analyzed Resources",
@@ -192,16 +191,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/7f080145-c535-4291-a15b-b91b0e3c00c6",
+          "triggerStep": "/api/3/workflow_steps/0dec07fb-8910-40a3-a010-fc498c2ff2f6",
           "steps": [
             {
-              "uuid": "7f080145-c535-4291-a15b-b91b0e3c00c6",
+              "uuid": "0dec07fb-8910-40a3-a010-fc498c2ff2f6",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "405dad68-6293-446c-bbbc-61845779dd64",
+                "route": "de366997-db84-488d-9d68-fdfc7ddf5427",
                 "title": "AWS Access Analyzer: List of Analyzed Resources",
                 "resources": [
                   "alerts"
@@ -221,7 +220,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "9f5205d8-ee0a-40c3-ada7-47cddc06bfce",
+              "uuid": "8e151cae-a6f9-4c7a-8094-aa72f884669b",
               "@type": "WorkflowStep",
               "name": "List of Analyzed Resources",
               "description": null,
@@ -231,8 +230,7 @@
                 "config": "''",
                 "params": {
                   "assume_role": false,
-                  "size": 10,
-                  "next_token": ""
+                  "size": 10
                 },
                 "version": "1.1.0",
                 "connector": "aws-access-analyzer",
@@ -250,19 +248,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "8213b24d-8f3d-4d2e-a324-b2bd699d2923",
+              "uuid": "f76c40f9-31bf-4dab-9ab2-2e82402c2207",
               "label": null,
               "isExecuted": false,
               "name": "Start-> List of Analyzed Resources",
-              "sourceStep": "/api/3/workflow_steps/7f080145-c535-4291-a15b-b91b0e3c00c6",
-              "targetStep": "/api/3/workflow_steps/9f5205d8-ee0a-40c3-ada7-47cddc06bfce"
+              "sourceStep": "/api/3/workflow_steps/0dec07fb-8910-40a3-a010-fc498c2ff2f6",
+              "targetStep": "/api/3/workflow_steps/8e151cae-a6f9-4c7a-8094-aa72f884669b"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "15b889a5-5a34-49ce-bd13-a28e529d757a",
-          "collection": "/api/3/workflow_collections/d3c514d1-b86b-45db-ac48-0b60cb26a57e",
+          "uuid": "1d6e9865-f353-440b-b290-c3d67f4729f2",
+          "collection": "/api/3/workflow_collections/147cc835-a091-42e7-be78-8260a167885e",
           "triggerLimit": null,
           "description": "Retrieves information about a resource that was analyzed by the specified analyzer based on the analyzer ARN and resource ARN you have specified. ",
           "name": "Details of an Analyzed Resources",
@@ -275,16 +273,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/6e814430-5dcc-473d-ac22-01a4d8a43a84",
+          "triggerStep": "/api/3/workflow_steps/bd52fa53-3c80-4c36-bae5-f206cec6be67",
           "steps": [
             {
-              "uuid": "6e814430-5dcc-473d-ac22-01a4d8a43a84",
+              "uuid": "bd52fa53-3c80-4c36-bae5-f206cec6be67",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "384a6e9e-a76b-4bd9-9583-9c123f45e7e8",
+                "route": "94bd81c7-15a7-45d2-9d3d-565153df945f",
                 "title": "AWS Access Analyzer: Details of an Analyzed Resources",
                 "resources": [
                   "alerts"
@@ -304,7 +302,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "4e2956a0-e8d3-4edf-bbf9-ae2b57a30f76",
+              "uuid": "00b682b4-85eb-4b24-90cc-b1a6df172155",
               "@type": "WorkflowStep",
               "name": "Details of an Analyzed Resources",
               "description": null,
@@ -331,19 +329,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "6d10244e-2b37-426c-940d-8f103b709230",
+              "uuid": "83a0d444-e59d-44e9-9036-9bf66804e555",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Details of an Analyzed Resources",
-              "sourceStep": "/api/3/workflow_steps/6e814430-5dcc-473d-ac22-01a4d8a43a84",
-              "targetStep": "/api/3/workflow_steps/4e2956a0-e8d3-4edf-bbf9-ae2b57a30f76"
+              "sourceStep": "/api/3/workflow_steps/bd52fa53-3c80-4c36-bae5-f206cec6be67",
+              "targetStep": "/api/3/workflow_steps/00b682b4-85eb-4b24-90cc-b1a6df172155"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "5326abe8-50a9-4107-bc7b-3f184390bc3e",
-          "collection": "/api/3/workflow_collections/d3c514d1-b86b-45db-ac48-0b60cb26a57e",
+          "uuid": "031a3bff-05df-43c9-994c-2eebf96ba643",
+          "collection": "/api/3/workflow_collections/147cc835-a091-42e7-be78-8260a167885e",
           "triggerLimit": null,
           "description": "Retrieves a list of findings generated by the specified analyzer based on the analyzer ARN and other input parameters you have specified. ",
           "name": "List of Findings",
@@ -356,16 +354,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/d981c3b8-9ac3-4af6-8726-f84d1d2578fc",
+          "triggerStep": "/api/3/workflow_steps/dc43206c-d6bf-424f-b21e-e8530cb06e57",
           "steps": [
             {
-              "uuid": "d981c3b8-9ac3-4af6-8726-f84d1d2578fc",
+              "uuid": "dc43206c-d6bf-424f-b21e-e8530cb06e57",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "1e87f9f9-a6b7-4efa-8156-8d19b012dd25",
+                "route": "10357b2e-fc5b-471b-a261-6e050238d4d6",
                 "title": "AWS Access Analyzer: List of Findings",
                 "resources": [
                   "alerts"
@@ -385,7 +383,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "16f23bd2-e82e-432a-abb9-3a39845dbcfe",
+              "uuid": "da3fe238-ba6a-4f98-a858-a565bf753538",
               "@type": "WorkflowStep",
               "name": "List of Findings",
               "description": null,
@@ -395,10 +393,7 @@
                 "config": "''",
                 "params": {
                   "assume_role": false,
-                  "size": 10,
-                  "filter": {},
-                  "sort": {},
-                  "next_token": ""
+                  "size": 10
                 },
                 "version": "1.1.0",
                 "connector": "aws-access-analyzer",
@@ -416,19 +411,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "334538ef-e911-4e8b-a289-65f562bf82ff",
+              "uuid": "c6752672-ac53-4dad-9c42-9ee401ba20d9",
               "label": null,
               "isExecuted": false,
               "name": "Start-> List of Findings",
-              "sourceStep": "/api/3/workflow_steps/d981c3b8-9ac3-4af6-8726-f84d1d2578fc",
-              "targetStep": "/api/3/workflow_steps/16f23bd2-e82e-432a-abb9-3a39845dbcfe"
+              "sourceStep": "/api/3/workflow_steps/dc43206c-d6bf-424f-b21e-e8530cb06e57",
+              "targetStep": "/api/3/workflow_steps/da3fe238-ba6a-4f98-a858-a565bf753538"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "23ce75d9-6460-4c9a-a5a3-b8bf89372848",
-          "collection": "/api/3/workflow_collections/d3c514d1-b86b-45db-ac48-0b60cb26a57e",
+          "uuid": "99f86549-1273-4fe2-a429-c70d1e385790",
+          "collection": "/api/3/workflow_collections/147cc835-a091-42e7-be78-8260a167885e",
           "triggerLimit": null,
           "description": "Retrieves information about the specified finding generated by the specified analyzer based on the analyzer ARN and finding ID you have specified.",
           "name": "Get Finding Details",
@@ -441,16 +436,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/dfa65620-9ec3-40fe-88b1-0cee9cae5c7d",
+          "triggerStep": "/api/3/workflow_steps/25dd7c21-539b-4736-abb8-dd3ed9cbdd7c",
           "steps": [
             {
-              "uuid": "dfa65620-9ec3-40fe-88b1-0cee9cae5c7d",
+              "uuid": "25dd7c21-539b-4736-abb8-dd3ed9cbdd7c",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "22e7f512-abb0-4412-a734-422fd15c9c70",
+                "route": "e636c363-4ac2-46e5-8e89-61fe2179883e",
                 "title": "AWS Access Analyzer: Get Finding Details",
                 "resources": [
                   "alerts"
@@ -470,7 +465,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "216efb0b-c045-40c9-9dfe-d03b9ff74139",
+              "uuid": "122dd14e-a42a-4072-9fc3-fed879abec5b",
               "@type": "WorkflowStep",
               "name": "Get Finding Details",
               "description": null,
@@ -479,8 +474,7 @@
                 "name": "AWS Access Analyzer",
                 "config": "''",
                 "params": {
-                  "assume_role": false,
-                  "id": ""
+                  "assume_role": false
                 },
                 "version": "1.1.0",
                 "connector": "aws-access-analyzer",
@@ -498,19 +492,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "d8460b07-bf0b-4fca-b47b-9fb470cdb77e",
+              "uuid": "2c46946c-8b6b-4f82-81b4-29e6e2ba8176",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Get Finding Details",
-              "sourceStep": "/api/3/workflow_steps/dfa65620-9ec3-40fe-88b1-0cee9cae5c7d",
-              "targetStep": "/api/3/workflow_steps/216efb0b-c045-40c9-9dfe-d03b9ff74139"
+              "sourceStep": "/api/3/workflow_steps/25dd7c21-539b-4736-abb8-dd3ed9cbdd7c",
+              "targetStep": "/api/3/workflow_steps/122dd14e-a42a-4072-9fc3-fed879abec5b"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "4acbb120-692d-4a20-b902-8cb29136bdc1",
-          "collection": "/api/3/workflow_collections/d3c514d1-b86b-45db-ac48-0b60cb26a57e",
+          "uuid": "6f2b5ea1-da34-4860-b663-13d0557d61e6",
+          "collection": "/api/3/workflow_collections/147cc835-a091-42e7-be78-8260a167885e",
           "triggerLimit": null,
           "description": "Immediately starts a scan of the policies applied to the specified resource based on the analyzer ARN and resource ARN you have specified. ",
           "name": "Start Resource Scan",
@@ -523,16 +517,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/09f0e2d2-7f1e-419b-8d35-88b414ef858d",
+          "triggerStep": "/api/3/workflow_steps/b86b2a06-4684-41d3-b805-911c3570ea7f",
           "steps": [
             {
-              "uuid": "09f0e2d2-7f1e-419b-8d35-88b414ef858d",
+              "uuid": "b86b2a06-4684-41d3-b805-911c3570ea7f",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "e03dabad-6413-4872-a231-a87cfa3aa51a",
+                "route": "d220717e-7bce-4125-9313-3c88f31f95a4",
                 "title": "AWS Access Analyzer: Start Resource Scan",
                 "resources": [
                   "alerts"
@@ -552,7 +546,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "8fdef468-544d-4498-bdcd-a2dc24f5cf3b",
+              "uuid": "57200d59-c4f4-4e62-b346-75c8d5142b6e",
               "@type": "WorkflowStep",
               "name": "Start Resource Scan",
               "description": null,
@@ -579,19 +573,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "7e368695-d041-41fb-a32b-d0c86e52936c",
+              "uuid": "71312ece-c318-4371-9fba-848e90af3433",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Start Resource Scan",
-              "sourceStep": "/api/3/workflow_steps/09f0e2d2-7f1e-419b-8d35-88b414ef858d",
-              "targetStep": "/api/3/workflow_steps/8fdef468-544d-4498-bdcd-a2dc24f5cf3b"
+              "sourceStep": "/api/3/workflow_steps/b86b2a06-4684-41d3-b805-911c3570ea7f",
+              "targetStep": "/api/3/workflow_steps/57200d59-c4f4-4e62-b346-75c8d5142b6e"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "3409f7eb-aa4d-418f-aab4-25e9f9a01871",
-          "collection": "/api/3/workflow_collections/d3c514d1-b86b-45db-ac48-0b60cb26a57e",
+          "uuid": "82e798c1-816f-4a55-a243-524feaa24448",
+          "collection": "/api/3/workflow_collections/147cc835-a091-42e7-be78-8260a167885e",
           "triggerLimit": null,
           "description": "Updates the status of the specified findings of a specified analyzer based on the analyzer ARN, resource ARN, findings IDs, and other input parameters you have specified. ",
           "name": "Update Findings Status",
@@ -604,16 +598,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/d5bf8a94-c5d9-45ad-87cd-65875eec36ce",
+          "triggerStep": "/api/3/workflow_steps/ca4e44bc-da67-4146-bff9-04e8f883d2e3",
           "steps": [
             {
-              "uuid": "d5bf8a94-c5d9-45ad-87cd-65875eec36ce",
+              "uuid": "ca4e44bc-da67-4146-bff9-04e8f883d2e3",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "3f299b63-3ab1-41be-89b5-76b5d3752e16",
+                "route": "1f59f11c-6f88-4b14-9773-a800c7b74529",
                 "title": "AWS Access Analyzer: Update Findings Status",
                 "resources": [
                   "alerts"
@@ -633,7 +627,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "5053b967-4f48-4d38-a31a-ec4713a972b7",
+              "uuid": "4af06a4a-5c31-42a3-919d-16e84792b950",
               "@type": "WorkflowStep",
               "name": "Update Findings Status",
               "description": null,
@@ -643,9 +637,8 @@
                 "config": "''",
                 "params": {
                   "assume_role": false,
-                  "ids": [],
-                  "status": "ACTIVE",
-                  "client_token": ""
+                  "update_by": "Resource ARN",
+                  "status": "ACTIVE"
                 },
                 "version": "1.1.0",
                 "connector": "aws-access-analyzer",
@@ -663,95 +656,12 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "826e2061-8d8a-449a-b40f-d9241b7e24fc",
+              "uuid": "65e05d12-a21c-4f9b-8975-bacb7c87fe44",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Update Findings Status",
-              "sourceStep": "/api/3/workflow_steps/d5bf8a94-c5d9-45ad-87cd-65875eec36ce",
-              "targetStep": "/api/3/workflow_steps/5053b967-4f48-4d38-a31a-ec4713a972b7"
-            }
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "uuid": "db82c034-02fc-42ce-bbe0-6a89afc20e3c",
-          "collection": "/api/3/workflow_collections/d3c514d1-b86b-45db-ac48-0b60cb26a57e",
-          "triggerLimit": null,
-          "description": "Retrieves a list of specified resource types that have been analyzed by the specified analyzer based on the analyzer ARN, resource type, and other input parameters you have specified. ",
-          "name": "Get Resources",
-          "tag": "#AWS Access Analyzer",
-          "recordTags": [
-            "aws-access-analyzer"
-          ],
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "parameters": [],
-          "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/578c6cd2-d9bd-49f3-93da-8329b644dc55",
-          "steps": [
-            {
-              "uuid": "578c6cd2-d9bd-49f3-93da-8329b644dc55",
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "route": "05b719dc-b949-46b6-937a-91cba2a59c87",
-                "title": "AWS Access Analyzer: Get Resources",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "singleRecordExecution": false,
-                "noRecordExecution": true,
-                "executeButtonText": "Execute"
-              },
-              "left": "20",
-              "top": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
-            },
-            {
-              "uuid": "7e12d975-6657-4552-a331-9e542cd8328c",
-              "@type": "WorkflowStep",
-              "name": "Get Resources",
-              "description": null,
-              "status": null,
-              "arguments": {
-                "name": "AWS Access Analyzer",
-                "config": "''",
-                "params": {
-                  "assume_role": false,
-                  "size": 10,
-                  "next_token": ""
-                },
-                "version": "1.1.0",
-                "connector": "aws-access-analyzer",
-                "operation": "get_resources",
-                "operationTitle": "Get Resources",
-                "step_variables": {
-                  "output_data": "{{vars.result}}"
-                }
-              },
-              "left": "188",
-              "top": "120",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "ae51e006-8314-472a-b6e8-36f178eee4ad",
-              "label": null,
-              "isExecuted": false,
-              "name": "Start-> Get Resources",
-              "sourceStep": "/api/3/workflow_steps/578c6cd2-d9bd-49f3-93da-8329b644dc55",
-              "targetStep": "/api/3/workflow_steps/7e12d975-6657-4552-a331-9e542cd8328c"
+              "sourceStep": "/api/3/workflow_steps/ca4e44bc-da67-4146-bff9-04e8f883d2e3",
+              "targetStep": "/api/3/workflow_steps/4af06a4a-5c31-42a3-919d-16e84792b950"
             }
           ]
         }


### PR DESCRIPTION
Descriptions: 
0847909:  In "Update Findings" action "Resource ARN" and "Findings IDs" both are not mandatory, and also we should only pass either "Resource ARN" or "Findings IDs".

0846585: In json params field, by default value is passed as string instead of json object(Platform issue). So, we figure out a work around by checking if empty dict value in str then replace it with empty dict(json) object.

Effected Actions:
1. List Findings
2. Update Findings Status

Unit Test Case:
1. Installed updated tgz successfully.
2. Verify "List of Findings" actions run successfully.
3. Verify "Update Findings Status" actions run successfully with both "Resource ARN" and "Findings IDs".